### PR TITLE
Fixing error on update-initramfs

### DIFF
--- a/client/ssh-client
+++ b/client/ssh-client
@@ -21,4 +21,5 @@ fi
 
 copy_exec /usr/bin/ssh
 mkdir -p $DESTDIR/lib/cryptsetup/scripts/
+mkdir -p $DESTDIR/root/.ssh/
 cp /lib/cryptsetup/scripts/get_key_ssh $DESTDIR/lib/cryptsetup/scripts/get_key_ssh


### PR DESCRIPTION
This fixes the issue of the missing .ssh folder on updating the
initrd. This seems to happen on a stretch/testing debian system.