### PR TITLE
Fixing host key verification error

### DIFF
--- a/client/get_key_ssh
+++ b/client/get_key_ssh
@@ -1,4 +1,4 @@
 #!/bin/sh
 sleep 5
 mac="$(ifconfig | grep HWaddr | awk '{ print $NF }')"
-ssh -i /root/.ssh/unlock_rsa -o ConnectTimeout=100 KEYHOST_ADDRESS "$mac"
+ssh -i /root/.ssh/unlock_rsa -o "UserKnownHostsFile=/root/.ssh/known_hosts ConnectTimeout=100" KEYHOST_ADDRESS "$mac"


### PR DESCRIPTION
This adds the "known hosts" option to the connect command by
dropbear. Otherwise it would complain about the host key while
booting and won't unlock our disk. This happens on a 
stretch/testing debian system.