### PR TITLE
This changes the working directory of the script

### DIFF
--- a/scripts/setupClient.sh
+++ b/scripts/setupClient.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd $(dirname "$0")/..
 keyHost=$1
 if [ "$(id -u)" != "0" ]; then
    echo "This script must be run as root" 1>&2

--- a/scripts/setupServer.sh
+++ b/scripts/setupServer.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd $(dirname "$0")
+cd $(dirname "$0")/..
 if [ "$#" -ne 2 ] ; then
         echo "Usage: $0 <clientName> <clientMac>"
         exit 0

--- a/scripts/setupServer.sh
+++ b/scripts/setupServer.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd $(dirname "$0")
 if [ "$#" -ne 2 ] ; then
         echo "Usage: $0 <clientName> <clientMac>"
         exit 0


### PR DESCRIPTION
This changes the working directory of the script, so that it will
_always_ use the root of the project. This will prevent the script
from running in a different working directory and failing to copy
some of the files. The error messages were quite subtle and
could've gotten unnoticed.

https://github.com/fetzerms/cryptboot-ssh/blob/master/scripts/setupClient.sh#L39-L46