### PR TITLE
Fixing keyserver client MAC address authentication

### DIFF
--- a/scripts/setupClient.sh
+++ b/scripts/setupClient.sh
@@ -54,8 +54,10 @@ echo "Please add this key to authorized_keys on $keyHost"
 echo "Press enter when finished"
 echo "command=\"./crypt-scripts/retrieve_"$HOSTNAME"_key\" `cat /etc/initramfs-tools/root/.ssh/unlock_rsa.pub`"
 read
+# Retrieve proper MAC address
+mac=$(cat /sys/class/net/$IF/address)
 # Retrieve keyfile
-ssh $keyHost -i /etc/initramfs-tools/root/.ssh/unlock_rsa -o UserKnownHostsFile=/etc/initramfs-tools/root/.ssh/known_hosts "cat .keyfiles/$HOSTNAME" > ./tmp-mount/keyfile
+ssh $keyHost -i /etc/initramfs-tools/root/.ssh/unlock_rsa -o UserKnownHostsFile=/etc/initramfs-tools/root/.ssh/known_hosts "$mac" > ./tmp-mount/keyfile
 echo "What is the path of the physical encrypted root partition? (e.g. /dev/sda1)"
 read PART
 # Add key to crypto device.


### PR DESCRIPTION
At this point the only possible response by the keyserver could've been (and was!) "nope!", since it only accepts the right MAC address, and not a `cat .keyfiles/$HOSTNAME`

https://github.com/459below/cryptboot-ssh/tree/fix-script-usability-2 is going to show a hash of the keyserver response, to prevent exactly this confusion in the future.