### PR TITLE
Using hashes for easy identity verification

### DIFF
--- a/scripts/setupClient.sh
+++ b/scripts/setupClient.sh
@@ -59,6 +59,7 @@ ssh $keyHost -i /etc/initramfs-tools/root/.ssh/unlock_rsa -o UserKnownHostsFile=
 # Verify keyfile
 echo "Please verify this hash for the keyfile to be correct. Abort, if they differ! (ecf255377f0f44003b40897ca41696c82fbe25dd would mean that MAC-Address verification has failed.)"
 sha1sum ./tmp-mount/keyfile | cut -c -40
+read
 echo "What is the path of the physical encrypted root partition? (e.g. /dev/sda1)"
 read PART
 # Add key to crypto device.

--- a/scripts/setupClient.sh
+++ b/scripts/setupClient.sh
@@ -60,7 +60,7 @@ mac=$(cat /sys/class/net/$IF/address)
 ssh $keyHost -i /etc/initramfs-tools/root/.ssh/unlock_rsa -o UserKnownHostsFile=/etc/initramfs-tools/root/.ssh/known_hosts "$mac" > ./tmp-mount/keyfile
 # Verify keyfile
 echo "Please verify this hash for the keyfile to be correct. Abort, if they differ! (ecf255377f0f44003b40897ca41696c82fbe25dd would mean that MAC-Address verification has failed.)"
-sha1sum ./tmp-mount/keyfile | cut -c -40
+sha1sum ./tmp-mount/keyfile | cut -d' ' -f1
 read
 
 echo "What is the path of the physical encrypted root partition? (e.g. /dev/sda1)"

--- a/scripts/setupClient.sh
+++ b/scripts/setupClient.sh
@@ -57,7 +57,7 @@ read
 # Retrieve keyfile
 ssh $keyHost -i /etc/initramfs-tools/root/.ssh/unlock_rsa -o UserKnownHostsFile=/etc/initramfs-tools/root/.ssh/known_hosts "cat .keyfiles/$HOSTNAME" > ./tmp-mount/keyfile
 # Verify keyfile
-echo "Please verify this hash for the keyfile to be correct. Abort, if they differ!"
+echo "Please verify this hash for the keyfile to be correct. Abort, if they differ! (ecf255377f0f44003b40897ca41696c82fbe25dd would mean that MAC-Address verification has failed.)"
 sha1sum ./tmp-mount/keyfile | cut -c -40
 echo "What is the path of the physical encrypted root partition? (e.g. /dev/sda1)"
 read PART

--- a/scripts/setupClient.sh
+++ b/scripts/setupClient.sh
@@ -56,6 +56,9 @@ echo "command=\"./crypt-scripts/retrieve_"$HOSTNAME"_key\" `cat /etc/initramfs-t
 read
 # Retrieve keyfile
 ssh $keyHost -i /etc/initramfs-tools/root/.ssh/unlock_rsa -o UserKnownHostsFile=/etc/initramfs-tools/root/.ssh/known_hosts "cat .keyfiles/$HOSTNAME" > ./tmp-mount/keyfile
+# Verify keyfile
+echo "Please verify this hash for the keyfile to be correct. Abort, if they differ!"
+sha1sum ./tmp-mount/keyfile | cut -c -40
 echo "What is the path of the physical encrypted root partition? (e.g. /dev/sda1)"
 read PART
 # Add key to crypto device.

--- a/scripts/setupServer.sh
+++ b/scripts/setupServer.sh
@@ -17,6 +17,8 @@ if [ ! -f ~/crypt-keys/"$clientName".keyfile ] ; then
 	dd bs=512 count=4 if=/dev/urandom of=~/crypt-keys/"$clientName".keyfile iflag=fullblock 
 fi
 
+echo "Note this keyfile's hash for later verification: $(sha1sum ~/crypt-keys/"$clientName".keyfile | cut -c -40 )"
+
 # Download the server-keyscript and make it executable
 cp server/retrieve_crypto_key ~/crypt-scripts/retrieve_"$clientName"_key
 chmod +x ~/crypt-scripts/retrieve_"$clientName"_key


### PR DESCRIPTION
This will use the sha1sums of the keyfiles so that the user may see if the wrong keyfile (or none at all) more quickly.