### PR TITLE
Android keyserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ These steps are executed on the **keyvm**. Variables are used.
 # The command option enforces the connecting client to only execute a specific command, which
 # will be the command to retrieve the crypt key. Other commands or interactive sessions are not 
 # possible with this key.
-user@keyvm:~$ echo "command=\"./crypt-scripts/retrieve_"$clientName"_key\" <<copied_unlock.rsa>>" >> ~/.ssh/authorized_keys
+user@keyvm:~$ echo "command=\"sh ./crypt-scripts/retrieve_"$clientName"_key\" <<copied_unlock.rsa>>" >> ~/.ssh/authorized_keys
 ```
 
 ### Adding cryptkeys to the cryptvm

--- a/scripts/setupClient.sh
+++ b/scripts/setupClient.sh
@@ -52,7 +52,7 @@ mkdir tmp-mount && mount -t tmpfs none ./tmp-mount
 # Waiting for user to authorize the new RSA key
 echo "Please add this key to authorized_keys on $keyHost"
 echo "Press enter when finished"
-echo "command=\"./crypt-scripts/retrieve_"$HOSTNAME"_key\" `cat /etc/initramfs-tools/root/.ssh/unlock_rsa.pub`"
+echo "command=\"sh ./crypt-scripts/retrieve_"$HOSTNAME"_key\" `cat /etc/initramfs-tools/root/.ssh/unlock_rsa.pub`"
 read
 # Retrieve proper MAC address
 mac=$(cat /sys/class/net/$IF/address)

--- a/server/retrieve_crypto_key
+++ b/server/retrieve_crypto_key
@@ -1,7 +1,7 @@
 #!/bin/bash
 macAddr=$( echo $SSH_ORIGINAL_COMMAND | tr '[:lower:]' '[:upper:]' )
 if [ ! -z "$macAddr" ]; then
-	hMacAddr=$( echo $macAddr | sha1sum | cut -c -40 )
+	hMacAddr=$( echo $macAddr | sha1sum | cut -d' ' -f1 )
 	checkHash="PLACEHOLDER_FOR_MAC_ADDRESS"
 
 	if [ "$hMacAddr" == "$checkHash" ]; then

--- a/server/retrieve_crypto_key
+++ b/server/retrieve_crypto_key
@@ -1,7 +1,7 @@
 #!/bin/bash
-macAddr="${SSH_ORIGINAL_COMMAND^^}"
+macAddr=$( echo $SSH_ORIGINAL_COMMAND | tr '[:lower:]' '[:upper:]' )
 if [ ! -z "$macAddr" ]; then
-	hMacAddr=$( echo $macAddr | sha1sum | awk '{ print $1 }' )
+	hMacAddr=$( echo $macAddr | sha1sum | cut -c -40 )
 	checkHash="PLACEHOLDER_FOR_MAC_ADDRESS"
 
 	if [ "$hMacAddr" == "$checkHash" ]; then


### PR DESCRIPTION
These changes are needed to use a stock unrooted Android device running [SimpleSSHD](https://play.google.com/store/apps/details?id=org.galexander.sshd&hl=en) (a Dropbear fork) as a keyserver. A howto on setting up the Android side still needs to be written, but these are the basic requirements.